### PR TITLE
Feature/before condition messaging

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.rjmetrics.developers/sweet-liberty "0.1.1"
+(defproject com.rjmetrics.developers/sweet-liberty "0.1.2-SNAPSHOT"
   :description "A library for building database-backed RESTful services using Clojure"
   :url "https://github.com/RJMetrics/sweet-liberty"
   :license {:name "Apache 2.0 License"

--- a/src/com/rjmetrics/sweet_liberty/core.clj
+++ b/src/com/rjmetrics/sweet_liberty/core.clj
@@ -284,13 +284,11 @@
     req))
 
 (defn force-response-through
-  [sweet-lib-config decision-point]
-  (let [current-fn (-> sweet-lib-config :liberator-config decision-point)
-        wrapped-fn (fn [ctx]
-                     (let [result (current-fn ctx)]
-                       (if (instance? RingResponse result)
-                         (throw (ex-info "Forcing a response through."
-                                         {:is-sweet-lib-exception? true
-                                          :ring-response result}))
-                         result)))]
-    (assoc-in sweet-lib-config [:liberator-config decision-point] wrapped-fn)))
+  [fn-to-wrap]
+  (fn [ctx]
+    (let [result (fn-to-wrap ctx)]
+      (if (instance? RingResponse result)
+        (throw (ex-info "Forcing a response through."
+                        {:is-sweet-lib-exception? true
+                         :ring-response result}))
+        result))))


### PR DESCRIPTION
This adds a helper function so that a user of sweet-liberty can return a HTTP response from any decision point. This is done by returning a `ring-response` from the decision function and then wrapping the decision function using the helper function `force-response-through`. I have tested this by both adding unit tests for it and using this functionality in the data-warehouse-service.
