### PR TITLE
Fixes filtering keys that have an underscore/dash in them.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.rjmetrics.developers/sweet-liberty "0.1.2"
+(defproject com.rjmetrics.developers/sweet-liberty "0.1.3-SNAPSHOT"
   :description "A library for building database-backed RESTful services using Clojure"
   :url "https://github.com/RJMetrics/sweet-liberty"
   :license {:name "Apache 2.0 License"
@@ -16,7 +16,7 @@
                  [org.clojure/data.json "0.2.4"]
                  [org.clojure/tools.logging "0.2.6"]
                  [org.slf4j/slf4j-log4j12 "1.6.1"]
-                 [camel-snake-kebab "0.2.2" :exclusions [org.clojure/clojure]]
+                 [camel-snake-kebab "0.3.2" :exclusions [org.clojure/clojure]]
                  [log4j/log4j "1.2.15" :exclusions [javax.mail/mail
                                                     javax.jms/jms
                                                     com.sun.jdmk/jmxtools
@@ -34,5 +34,4 @@
                              [s3-wagon-private "1.1.2"]
                              [codox "0.6.7"]
                              [lein-kibit "0.0.8"]
-                             [jonase/eastwood "0.1.1"]
-                             [lein-release "1.0.5"]]}})
+                             [jonase/eastwood "0.1.1"]]}})

--- a/src/com/rjmetrics/sweet_liberty/expansion.clj
+++ b/src/com/rjmetrics/sweet_liberty/expansion.clj
@@ -5,7 +5,7 @@
             [clojure.walk :refer [keywordize-keys]]
             [clojure.tools.logging :as log]
             [clojure.data.json :as json]
-            [camel-snake-kebab.core :refer [->kebab-case-keyword]]))
+            [camel-snake-kebab.core :refer [->snake_case_keyword]]))
 
 (defn- call-service-broker-with-logging
   [service-broker options]
@@ -37,7 +37,7 @@
                        :url-params route-params
                        :request-options request-params}))
       (try
-        (json/read-str (:body sb-result) :key-fn ->kebab-case-keyword)
+        (json/read-str (:body sb-result) :key-fn ->snake_case_keyword)
         (catch Exception e
           (:body sb-result))))))
 

--- a/src/com/rjmetrics/sweet_liberty/query.clj
+++ b/src/com/rjmetrics/sweet_liberty/query.clj
@@ -2,14 +2,17 @@
   (:require [honeysql.core :as sql]
             [honeysql.helpers :refer :all]
             [com.rjmetrics.sweet-liberty.util :as util]
-            [clojure.walk :refer [keywordize-keys]]))
+            [clojure.walk :refer [keywordize-keys]]
+            [camel-snake-kebab.core :refer [->snake_case_keyword]]
+            [camel-snake-kebab.extras :refer [transform-keys]]))
 
 (defn get-filter-map
   "Returns the filters from the query params Map as a Map of keyword fields to values.
   (:attributes table-struct) acts as a whitelist for which items to take.
   (get-filter-map {:columnA value1 :_fields [\"name\"]'} returns {:columnA value1}"
   [query-params table-struct]
-  (select-keys (keywordize-keys query-params) (:attributes table-struct)))
+  (select-keys (transform-keys ->snake_case_keyword query-params)
+               (:attributes table-struct)))
 
 (defn create-default-h-sql-map
   "Returns default Honey-Sql query Map with the :select and :from keys set to the proper attributes

--- a/test/com/rjmetrics/sweet_liberty/unit/t_query.clj
+++ b/test/com/rjmetrics/sweet_liberty/unit/t_query.clj
@@ -4,16 +4,16 @@
 
 (facts "get-filter-map returns the filters from the query params map as a map of keywords"
        (fact "when the filter column name is a keyword"
-             (get-filter-map {"_fields" ["x" "y" "zzz"] :column-name 4} {:attributes [:column-name]})
-             => {:column-name 4})
+             (get-filter-map {"_fields" ["x" "y" "zzz"] :column-name 4} {:attributes [:column_name]})
+             => {:column_name 4})
        (fact "when the filter column name is a string"
-             (get-filter-map {"_fields" ["x" "y" "zzz"] "column-name" 4} {:attributes [:column-name]})
-             => {:column-name 4}))
+             (get-filter-map {"_fields" ["x" "y" "zzz"] "column-name" 4} {:attributes [:column_name]})
+             => {:column_name 4}))
 
 (fact "create-default-h-sql-map returns the default Honey-Sql query Map with the :select and :from keys set properly."
-      (create-default-h-sql-map {:attributes [:column-name :another-column-name]
+      (create-default-h-sql-map {:attributes [:column_name :another_column_name]
                                  :table-name :table-name})
-      => {:select [:column-name :another-column-name] :from [:table-name]})
+      => {:select [:column_name :another_column_name] :from [:table-name]})
 
 (facts "set-field-list"
        (let [h-sql-map {:select [:*]
@@ -66,8 +66,8 @@
                    :where [:and [:= :final-column "3"][:= :another-column-name "1"][:in :column-name ["a" "2" "b"]]]})))
 
 (facts "build-paging-query returns a properly formatted sql string and params to be passed to jdbc when given no paging options"
-       (let [table-structure {:attributes [:column-name
-                                           :another-column-name]
+       (let [table-structure {:attributes [:column_name
+                                           :another_column_name]
                               :table-name :table-name}]
          (fact "when there are no query params."
                (build-paging-query table-structure {})
@@ -80,7 +80,7 @@
                => ["SELECT column1, column2 FROM table_name"])
          (fact "when there is a filter query-param."
                (build-paging-query table-structure {:column-name 1
-                                                         :another-column-name 2})
+                                                    :another-column-name 2})
                => ["SELECT column_name, another_column_name FROM table_name WHERE (another_column_name = ? AND column_name = ?)"
                    "2"
                    "1"])


### PR DESCRIPTION
This PR fixes a bug where if a column you were filtering by had a underscore/dash in the name the field would not be used to filter.

I've tested this by using it from the core service.
